### PR TITLE
Add Flutter UI prototype for AI learning app

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'screens/login_screen.dart';
+import 'screens/chat_screen.dart';
+
+void main() {
+  runApp(const AiLearningApp());
+}
+
+class AiLearningApp extends StatelessWidget {
+  const AiLearningApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'AI Learning',
+      debugShowCheckedModeBanner: false,
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Colors.indigo,
+          brightness: Brightness.light,
+        ),
+        useMaterial3: true,
+        textTheme: const TextTheme(
+          titleLarge: TextStyle(fontWeight: FontWeight.bold),
+        ),
+      ),
+      home: const LoginScreen(),
+      routes: {
+        ChatScreen.routeName: (_) => const ChatScreen(),
+      },
+    );
+  }
+}

--- a/lib/models/message.dart
+++ b/lib/models/message.dart
@@ -1,0 +1,13 @@
+class Message {
+  Message({
+    required this.id,
+    required this.text,
+    required this.isUser,
+    this.timestamp,
+  });
+
+  final String id;
+  final String text;
+  final bool isUser;
+  final DateTime? timestamp;
+}

--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -1,0 +1,383 @@
+import 'package:flutter/material.dart';
+import '../models/message.dart';
+import '../widgets/message_bubble.dart';
+
+class ChatScreen extends StatefulWidget {
+  const ChatScreen({super.key});
+
+  static const routeName = '/chat';
+
+  @override
+  State<ChatScreen> createState() => _ChatScreenState();
+}
+
+class _ChatScreenState extends State<ChatScreen> {
+  final List<Message> _messages = [];
+  final TextEditingController _inputController = TextEditingController();
+  final ScrollController _scrollController = ScrollController();
+  String _selectedModel = '默认模型';
+
+  final List<String> _availableModels = const [
+    '默认模型',
+    '英语学习助手',
+    '编程导师',
+    '数学解题',
+  ];
+
+  @override
+  void dispose() {
+    _inputController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _createNewConversation() {
+    setState(() {
+      _messages.clear();
+    });
+  }
+
+  void _sendMessage() {
+    final text = _inputController.text.trim();
+    if (text.isEmpty) return;
+
+    setState(() {
+      _messages.add(
+        Message(
+          id: DateTime.now().millisecondsSinceEpoch.toString(),
+          text: text,
+          isUser: true,
+          timestamp: DateTime.now(),
+        ),
+      );
+      _messages.add(
+        Message(
+          id: '${DateTime.now().millisecondsSinceEpoch}-ai',
+          text: '这里是AI回复的示例内容，用于展示界面效果。',
+          isUser: false,
+          timestamp: DateTime.now(),
+        ),
+      );
+    });
+
+    _inputController.clear();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _scrollController.animateTo(
+        _scrollController.position.maxScrollExtent,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeOut,
+      );
+    });
+  }
+
+  void _showModelSelector() {
+    showModalBottomSheet(
+      context: context,
+      showDragHandle: true,
+      builder: (context) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Padding(
+                padding: EdgeInsets.symmetric(vertical: 16),
+                child: Text(
+                  '选择AI模型',
+                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                ),
+              ),
+              ..._availableModels.map(
+                (model) => ListTile(
+                  title: Text(model),
+                  trailing: model == _selectedModel
+                      ? const Icon(Icons.check, color: Colors.indigo)
+                      : null,
+                  onTap: () {
+                    setState(() => _selectedModel = model);
+                    Navigator.of(context).pop();
+                  },
+                ),
+              ),
+              const SizedBox(height: 8),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('AI 学习助手'),
+        centerTitle: true,
+      ),
+      drawer: _ConversationList(onNewConversation: _createNewConversation),
+      endDrawer: const _SettingsDrawer(),
+      body: Column(
+        children: [
+          Expanded(
+            child: _messages.isEmpty
+                ? _EmptyConversation(onCreate: _createNewConversation)
+                : ListView.builder(
+                    controller: _scrollController,
+                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                    itemCount: _messages.length,
+                    itemBuilder: (context, index) {
+                      final message = _messages[index];
+                      return MessageBubble(
+                        message: message,
+                        onShowActions: message.isUser
+                            ? null
+                            : () => _showMessageActions(message),
+                      );
+                    },
+                  ),
+          ),
+          _InputArea(
+            controller: _inputController,
+            selectedModel: _selectedModel,
+            onModelTap: _showModelSelector,
+            onSend: _sendMessage,
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showMessageActions(Message _) {
+    showModalBottomSheet(
+      context: context,
+      showDragHandle: true,
+      builder: (context) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: const [
+              ListTile(title: Text('操作1')),
+              ListTile(title: Text('操作2')),
+              ListTile(title: Text('操作3')),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _ConversationList extends StatelessWidget {
+  const _ConversationList({required this.onNewConversation});
+
+  final VoidCallback onNewConversation;
+
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+      child: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Padding(
+              padding: EdgeInsets.all(16),
+              child: Text(
+                '对话列表',
+                style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+              ),
+            ),
+            Expanded(
+              child: ListView.builder(
+                itemCount: 6,
+                itemBuilder: (context, index) {
+                  return ListTile(
+                    leading: CircleAvatar(child: Text('${index + 1}')),
+                    title: Text('对话 ${index + 1}'),
+                    subtitle: const Text('上次更新：昨天'),
+                    onTap: () => Navigator.of(context).pop(),
+                  );
+                },
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: SizedBox(
+                width: double.infinity,
+                child: OutlinedButton.icon(
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                    onNewConversation();
+                  },
+                  icon: const Icon(Icons.add),
+                  label: const Text('新建对话'),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SettingsDrawer extends StatelessWidget {
+  const _SettingsDrawer();
+
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+      child: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            const Text(
+              '设置',
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 16),
+            const ListTile(
+              leading: Icon(Icons.person_outline),
+              title: Text('账户管理'),
+            ),
+            const ListTile(
+              leading: Icon(Icons.edit_note_outlined),
+              title: Text('填写资料'),
+            ),
+            const ListTile(
+              leading: Icon(Icons.workspace_premium_outlined),
+              title: Text('订阅套餐'),
+            ),
+            const ListTile(
+              leading: Icon(Icons.language_outlined),
+              title: Text('设置语言'),
+            ),
+            const ListTile(
+              leading: Icon(Icons.dark_mode_outlined),
+              title: Text('主题设置'),
+            ),
+            const Divider(),
+            ListTile(
+              leading: const Icon(Icons.logout),
+              title: const Text('退出登录'),
+              onTap: () {
+                Navigator.of(context)
+                  ..pop()
+                  ..pop();
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _InputArea extends StatelessWidget {
+  const _InputArea({
+    required this.controller,
+    required this.selectedModel,
+    required this.onModelTap,
+    required this.onSend,
+  });
+
+  final TextEditingController controller;
+  final String selectedModel;
+  final VoidCallback onModelTap;
+  final VoidCallback onSend;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Container(
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surface,
+          border: Border(
+            top: BorderSide(
+              color: Theme.of(context).colorScheme.outlineVariant,
+            ),
+          ),
+        ),
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton.icon(
+                onPressed: onModelTap,
+                icon: const Icon(Icons.memory_outlined),
+                label: Text(selectedModel),
+              ),
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: controller,
+                    minLines: 1,
+                    maxLines: 4,
+                    decoration: const InputDecoration(
+                      hintText: '请输入要发送的内容…',
+                      border: OutlineInputBorder(),
+                      isDense: true,
+                      contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                FilledButton(
+                  onPressed: onSend,
+                  child: const Icon(Icons.send_rounded),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyConversation extends StatelessWidget {
+  const _EmptyConversation({required this.onCreate});
+
+  final VoidCallback onCreate;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.chat_bubble_outline_rounded,
+              size: 72,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              '还没有对话',
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              '点击下方按钮开始你的第一次学习对话。',
+              textAlign: TextAlign.center,
+              style: TextStyle(color: Colors.black54),
+            ),
+            const SizedBox(height: 24),
+            FilledButton.icon(
+              onPressed: onCreate,
+              icon: const Icon(Icons.add_comment_rounded),
+              label: const Text('新建对话'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'chat_screen.dart';
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final TextEditingController _phoneController = TextEditingController();
+  final TextEditingController _codeController = TextEditingController();
+
+  bool _isRequestingCode = false;
+
+  @override
+  void dispose() {
+    _phoneController.dispose();
+    _codeController.dispose();
+    super.dispose();
+  }
+
+  void _requestCode() {
+    if (_formKey.currentState?.validate() ?? false) {
+      setState(() {
+        _isRequestingCode = true;
+      });
+      Future.delayed(const Duration(seconds: 1), () {
+        if (mounted) {
+          setState(() {
+            _isRequestingCode = false;
+          });
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('验证码已发送')), // verification code sent
+          );
+        }
+      });
+    }
+  }
+
+  void _login() {
+    if (_formKey.currentState?.validate() ?? false) {
+      Navigator.of(context).pushReplacementNamed(ChatScreen.routeName);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const SizedBox(height: 48),
+              Text(
+                '欢迎回来',
+                style: Theme.of(context).textTheme.headlineMedium,
+              ),
+              const SizedBox(height: 12),
+              const Text(
+                '使用手机号码登录以继续学习。',
+                style: TextStyle(color: Colors.black54),
+              ),
+              const SizedBox(height: 32),
+              Form(
+                key: _formKey,
+                child: Column(
+                  children: [
+                    TextFormField(
+                      controller: _phoneController,
+                      keyboardType: TextInputType.phone,
+                      decoration: const InputDecoration(
+                        labelText: '手机号码',
+                        prefixText: '+86 ',
+                        border: OutlineInputBorder(),
+                      ),
+                      validator: (value) {
+                        if (value == null || value.isEmpty) {
+                          return '请输入手机号码';
+                        }
+                        if (value.length < 6) {
+                          return '手机号码格式不正确';
+                        }
+                        return null;
+                      },
+                    ),
+                    const SizedBox(height: 16),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: TextFormField(
+                            controller: _codeController,
+                            keyboardType: TextInputType.number,
+                            decoration: const InputDecoration(
+                              labelText: '验证码',
+                              border: OutlineInputBorder(),
+                            ),
+                            validator: (value) {
+                              if (value == null || value.isEmpty) {
+                                return '请输入验证码';
+                              }
+                              return null;
+                            },
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        ElevatedButton(
+                          onPressed: _isRequestingCode ? null : _requestCode,
+                          child: _isRequestingCode
+                              ? const SizedBox(
+                                  width: 18,
+                                  height: 18,
+                                  child: CircularProgressIndicator(strokeWidth: 2),
+                                )
+                              : const Text('获取'),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 32),
+                    SizedBox(
+                      width: double.infinity,
+                      child: ElevatedButton(
+                        onPressed: _login,
+                        child: const Padding(
+                          padding: EdgeInsets.symmetric(vertical: 14),
+                          child: Text('登录'),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 24),
+              const Text(
+                '继续登录即表示您同意我们的服务条款和隐私政策。',
+                style: TextStyle(fontSize: 12, color: Colors.black45),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/message_bubble.dart
+++ b/lib/widgets/message_bubble.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import '../models/message.dart';
+
+class MessageBubble extends StatelessWidget {
+  const MessageBubble({
+    super.key,
+    required this.message,
+    this.onShowActions,
+  });
+
+  final Message message;
+  final VoidCallback? onShowActions;
+
+  @override
+  Widget build(BuildContext context) {
+    final alignment = message.isUser ? Alignment.centerRight : Alignment.centerLeft;
+    final bubbleColor = message.isUser
+        ? Theme.of(context).colorScheme.primary
+        : Theme.of(context).colorScheme.surfaceVariant;
+    final textColor = message.isUser ? Colors.white : Colors.black87;
+
+    Widget bubble = Container(
+      constraints: const BoxConstraints(maxWidth: 320),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: BoxDecoration(
+        color: bubbleColor,
+        borderRadius: BorderRadius.only(
+          topLeft: const Radius.circular(20),
+          topRight: const Radius.circular(20),
+          bottomLeft: Radius.circular(message.isUser ? 20 : 6),
+          bottomRight: Radius.circular(message.isUser ? 6 : 20),
+        ),
+      ),
+      child: Text(message.text, style: TextStyle(color: textColor, height: 1.4)),
+    );
+
+    if (!message.isUser && onShowActions != null) {
+      bubble = GestureDetector(
+        onLongPress: onShowActions,
+        onSecondaryTap: onShowActions,
+        child: bubble,
+      );
+    }
+
+    return Align(
+      alignment: alignment,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 6),
+        child: bubble,
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,20 @@
+name: ai_learning_app
+version: 0.1.0
+publish_to: 'none'
+description: A simple front-end prototype for an AI assisted learning app.
+environment:
+  sdk: '>=2.17.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+  cupertino_icons: ^1.0.5
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.0
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add a Flutter application scaffold with login and chat flows
- implement chat screen with conversation drawer, settings drawer, model selector, and placeholder message actions
- create reusable message bubble widget and basic message model for future data integration

## Testing
- `dart format lib` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d8d0286a9c832fb1bff02aedca0522